### PR TITLE
added asan to catch leaks

### DIFF
--- a/.github/workflows/ubuntu_clang.yaml
+++ b/.github/workflows/ubuntu_clang.yaml
@@ -5,68 +5,38 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
+        profile: ["Release", "Debug", "Asan"]
         configuration: [
-          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-         
+          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","CXX_STANDARD": 14 },
+          #{ "PACKAGE":"clang-3.9", "COMPILER":"clang", "COMPILER_VER":"3.9", "COMPILER_C": "clang-3.9","COMPILER_CXX": "clang++-3.9","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","CXX_STANDARD": 14 },
+          #{ "PACKAGE":"clang-4.0", "COMPILER":"clang", "COMPILER_VER":"4.0", "COMPILER_C": "clang-4.0","COMPILER_CXX": "clang++-4.0","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-5.0", "COMPILER":"clang", "COMPILER_VER":"5.0", "COMPILER_C": "clang-5.0","COMPILER_CXX": "clang++-5.0","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-6.0", "COMPILER":"clang", "COMPILER_VER":"6.0", "COMPILER_C": "clang-6.0","COMPILER_CXX": "clang++-6.0","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-7", "COMPILER":"clang", "COMPILER_VER":"7.0", "COMPILER_C": "clang-7","COMPILER_CXX": "clang++-7","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-8", "COMPILER":"clang", "COMPILER_VER":"8", "COMPILER_C": "clang-8","COMPILER_CXX": "clang++-8","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-9", "COMPILER":"clang", "COMPILER_VER":"9", "COMPILER_C": "clang-9","COMPILER_CXX": "clang++-9","CXX_STANDARD": 17 },
+          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","CXX_STANDARD": 11 },
+          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","CXX_STANDARD": 14 },
+          { "PACKAGE":"clang-10", "COMPILER":"clang", "COMPILER_VER":"10", "COMPILER_C": "clang-10","COMPILER_CXX": "clang++-10","CXX_STANDARD": 17 },
+          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","CXX_STANDARD": 11 },
+          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","CXX_STANDARD": 14 },
+          #{ "PACKAGE":"clang-11", "COMPILER":"clang", "COMPILER_VER":"11", "COMPILER_C": "clang-11","COMPILER_CXX": "clang++-11","CXX_STANDARD": 17 },
+          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","CXX_STANDARD": 11 },
+          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","CXX_STANDARD": 14 },
+          #{ "PACKAGE":"clang-12", "COMPILER":"clang", "COMPILER_VER":"12", "COMPILER_C": "clang-12","COMPILER_CXX": "clang++-12","CXX_STANDARD": 17 },
         ]
 
     steps:
@@ -93,10 +63,10 @@ jobs:
         env:
           CC: ${{ matrix.configuration.COMPILER_C}}
           CXX: ${{ matrix.configuration.COMPILER_CXX}}
-        run: cmake -B ${{github.workspace}}/build -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.configuration.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=${{ matrix.configuration.CXX_STANDARD}} -DALLOW_EXAMPLES=ON -DALLOW_TESTS=ON
+        run: cmake -B ${{github.workspace}}/build -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.profile}} -DCMAKE_CXX_STANDARD=${{ matrix.configuration.CXX_STANDARD}} -DALLOW_EXAMPLES=ON -DALLOW_TESTS=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.configuration.BUILD_TYPE}}
+        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.profile}}
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu_clang.yaml
+++ b/.github/workflows/ubuntu_clang.yaml
@@ -70,5 +70,5 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}}
+        run: ctest -C ${{env.BUILD_TYPE}} --rerun-failed --output-on-failure
       

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -5,49 +5,16 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
+        standard: [11, 14, 17]
+        profile: ["Release", "Debug", "Asan"]
         configuration: [
-          #{ "COMPILER_C": "gcc-4.8", "COMPILER":"gcc", "COMPILER_VER":"4.8", "COMPILER_CXX": "gcc-4.8","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          #{ "COMPILER_C": "gcc-4.8", "COMPILER":"gcc", "COMPILER_VER":"4.8", "COMPILER_CXX": "gcc-4.8","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          #{ "COMPILER_C": "gcc-4.9", "COMPILER":"gcc", "COMPILER_VER":"4.9", "COMPILER_CXX": "g++-4.9","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          #{ "COMPILER_C": "gcc-4.9", "COMPILER":"gcc", "COMPILER_VER":"4.9", "COMPILER_CXX": "g++-4.9","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-5", "COMPILER":"gcc", "COMPILER_VER":"5", "COMPILER_CXX": "g++-5","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-5", "COMPILER":"gcc", "COMPILER_VER":"5", "COMPILER_CXX": "g++-5","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-5", "COMPILER":"gcc", "COMPILER_VER":"5", "COMPILER_CXX": "g++-5","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-5", "COMPILER":"gcc", "COMPILER_VER":"5", "COMPILER_CXX": "g++-5","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-6", "COMPILER":"gcc", "COMPILER_VER":"6", "COMPILER_CXX": "g++-6","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-6", "COMPILER":"gcc", "COMPILER_VER":"6", "COMPILER_CXX": "g++-6","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-6", "COMPILER":"gcc", "COMPILER_VER":"6", "COMPILER_CXX": "g++-6","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-6", "COMPILER":"gcc", "COMPILER_VER":"6", "COMPILER_CXX": "g++-6","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          #{ "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          #{ "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10","BUILD_TYPE": "Debug","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Release","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 11 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Release","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 14 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Release","CXX_STANDARD": 17 },
-          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11","BUILD_TYPE": "Debug","CXX_STANDARD": 17 }
+          { "COMPILER_C": "gcc-5", "COMPILER":"gcc", "COMPILER_VER":"5", "COMPILER_CXX": "g++-5"},
+          { "COMPILER_C": "gcc-6", "COMPILER":"gcc", "COMPILER_VER":"6", "COMPILER_CXX": "g++-6"},
+          { "COMPILER_C": "gcc-7", "COMPILER":"gcc", "COMPILER_VER":"7", "COMPILER_CXX": "g++-7"},
+          { "COMPILER_C": "gcc-8", "COMPILER":"gcc", "COMPILER_VER":"8", "COMPILER_CXX": "g++-8"},
+          { "COMPILER_C": "gcc-9", "COMPILER":"gcc", "COMPILER_VER":"9", "COMPILER_CXX": "g++-9"},
+          { "COMPILER_C": "gcc-10", "COMPILER":"gcc", "COMPILER_VER":"10", "COMPILER_CXX": "g++-10"},
+          { "COMPILER_C": "gcc-11", "COMPILER":"gcc", "COMPILER_VER":"11", "COMPILER_CXX": "g++-11"},
         ]
 
     steps:
@@ -75,10 +42,10 @@ jobs:
         env:
           CC: ${{ matrix.configuration.COMPILER_C}}
           CXX: ${{ matrix.configuration.COMPILER_CXX}}
-        run: cmake -B ${{github.workspace}}/build -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.configuration.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=${{ matrix.configuration.CXX_STANDARD}} -DALLOW_EXAMPLES=ON -DALLOW_TESTS=ON
+        run: cmake -B ${{github.workspace}}/build -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.profile}} -DCMAKE_CXX_STANDARD=${{ matrix.standard}} -DALLOW_EXAMPLES=ON -DALLOW_TESTS=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.configuration.BUILD_TYPE}}
+        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.profile}}
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -49,5 +49,4 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}}
-      
+        run: ctest -C ${{env.BUILD_TYPE}} --rerun-failed --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.9)
 
 PROJECT(actor-zeta CXX)
 
@@ -23,6 +23,8 @@ message(STATUS "ALLOW_EXAMPLES = ${ALLOW_EXAMPLES}")
 message(STATUS "ALLOW_TESTS = ${ALLOW_TESTS}")
 message(STATUS "RTTI_DISABLE = ${RTTI_DISABLE}")
 message(STATUS "EXCEPTIONS_DISABLE = ${EXCEPTIONS_DISABLE}")
+
+include(cmake/profiles.cmake)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 

--- a/cmake/profiles.cmake
+++ b/cmake/profiles.cmake
@@ -1,0 +1,49 @@
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if(isMultiConfig)
+    if(NOT "Asan" IN_LIST CMAKE_CONFIGURATION_TYPES)
+        list(APPEND CMAKE_CONFIGURATION_TYPES Asan)
+    endif()
+    if(NOT "Ub" IN_LIST CMAKE_CONFIGURATION_TYPES)
+        list(APPEND CMAKE_CONFIGURATION_TYPES Ub)
+    endif()
+else()
+    set(allowedBuildTypes Asan Ub Debug Release RelWithDebInfo MinSizeRel)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowedBuildTypes}")
+
+    if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
+        message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
+    endif()
+endif()
+
+set(CMAKE_C_FLAGS_ASAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler for Asan build type or configuration." FORCE)
+
+set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler for Asan build type or configuration." FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+    "Linker flags to be used to create executables for Asan build type." FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+    "Linker lags to be used to create shared libraries for Asan build type." FORCE)
+
+set(CMAKE_C_FLAGS_UB
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler for Ub build type or configuration." FORCE)
+
+set(CMAKE_CXX_FLAGS_UB
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler for Ub build type or configuration." FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_UB
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined" CACHE STRING
+    "Linker flags to be used to create executables for Ub build type." FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_UB
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined" CACHE STRING
+    "Linker lags to be used to create shared libraries for Ub build type." FORCE)


### PR DESCRIPTION
current develop has leaks. steps to reproduce:

```
git clone https://github.com/cyberduckninja/actor-zeta
cd actor-zeta
git checkout ci
mkdir build
cd build
CXX=g++-8 CC=gcc-8 conan install .. --build=missing
CXX=g++-8 CC=gcc-8 cmake .. -DCMAKE_BUILD_TYPE=Asan \
   -DRTTI_DISABLE=OFF \
   -DALLOW_EXAMPLES=ON \
   -DALLOW_TESTS=ON \
   -DEXCEPTIONS_DISABLE=OFF \
   -DCMAKE_CXX_STANDARD=17
cmake --build . --parallel
./bin/handler
```

example output with leaks:
```
#... a lot of other leaks here
Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f4898595957 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x564a326534d4 in actor_zeta::base::supervisor_abstract::supervisor_abstract(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/user/gits/actor-zeta-fork/sou
rce/actor/supervisor_abstract.cpp:77
    #2 0x564a32501d78 in dummy_supervisor::dummy_supervisor(unsigned long, unsigned long) (/home/user/gits/actor-zeta-fork/build/bin/handler+0x287d78)
    #3 0x564a324bdfbe in ____C_A_T_C_H____T_E_S_T____0 /home/user/gits/actor-zeta-fork/test/handler/main.cpp:7
    #4 0x564a3248d8e2 in Catch::TestInvokerAsFunction::invoke() const /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:14317
    #5 0x564a3248b5fb in Catch::TestCase::invoke() const /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:14156
    #6 0x564a3247d76f in Catch::RunContext::invokeActiveTestCase() /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:13016
    #7 0x564a3247cf49 in Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std:
:allocator<char> >&) /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:12989
    #8 0x564a32479728 in Catch::RunContext::runTest(Catch::TestCase const&) /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:12750
    #9 0x564a32481b04 in execute /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:13343
    #10 0x564a32484809 in Catch::Session::runInternal() /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:13549
    #11 0x564a3248412d in Catch::Session::run() /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:13505
    #12 0x564a3252b56f in int Catch::Session::run<char>(int, char const* const*) (/home/user/gits/actor-zeta-fork/build/bin/handler+0x2b156f)
    #13 0x564a324bc614 in main /home/user/.conan/data/catch2/2.13.6/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/catch.hpp:17504
    #14 0x7f4897f1e564 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x28564)

SUMMARY: AddressSanitizer: 4705 byte(s) leaked in 86 allocation(s).

```