### PR TITLE
Switch to compiler-rt LLVM compiler runtime

### DIFF
--- a/.github/workflows/ubuntu_clang.yaml
+++ b/.github/workflows/ubuntu_clang.yaml
@@ -40,7 +40,7 @@ jobs:
       image: ubuntu:${{matrix.configuration.UBUNTU_VERSION}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         env:
@@ -99,3 +99,7 @@ jobs:
       - name: Test
         working-directory: build
         run: ctest --rerun-failed --output-on-failure
+
+      - name: Analyze dependencies
+        working-directory: build
+        run: ldd bin/dataflow

--- a/.github/workflows/ubuntu_clang.yaml
+++ b/.github/workflows/ubuntu_clang.yaml
@@ -40,7 +40,7 @@ jobs:
       image: ubuntu:${{matrix.configuration.UBUNTU_VERSION}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Install system dependencies
         env:

--- a/.github/workflows/ubuntu_clang.yaml
+++ b/.github/workflows/ubuntu_clang.yaml
@@ -65,9 +65,9 @@ jobs:
             | grep -Po "^Package: [a-zA-Z0-9-.\+ ]+$" \
             | sed -e 's/Package:/ /g' \
             | sed -e 's/[+\.a-zA-Z0-9-]*wasm[+\.a-zA-Z0-9-]*$/ /g' \
-            | sed -e 's/[+\.a-zA-Z0-9-]*-tools$/ /g' \
             | sed -e 's/[+\.a-zA-Z0-9-]*polly[+\.a-zA-Z0-9-]*$/ /g' \
             | sed -e 's/[+\.a-zA-Z0-9-]*python[+\.a-zA-Z0-9-]*$/ /g' \
+            | sed -e 's/.*-\(doc\|tools\|examples\|format\|tidy\|ocaml\|fuzzer\).*$/ /g' \
             > pkglist
 
           cat pkglist

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -36,7 +36,7 @@ jobs:
       image: ubuntu:${{matrix.configuration.UBUNTU_VERSION}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         env:
@@ -90,3 +90,7 @@ jobs:
       - name: Test
         working-directory: build
         run: ctest --rerun-failed --output-on-failure
+
+      - name: Analyze dependencies
+        working-directory: build
+        run: ldd bin/dataflow

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -36,7 +36,7 @@ jobs:
       image: ubuntu:${{matrix.configuration.UBUNTU_VERSION}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Install system dependencies
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,12 +122,18 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
     message(STATUS "Find CLANG_LIBCPP=${CLANG_LIBCPP}")
     message(STATUS "Find CLANG_LIBCPP_ABI=${CLANG_LIBCPP_ABI}")
     ### https://stackoverflow.com/questions/43662736/cmake-switch-between-clang-g-and-libc-libstdc
+
+    # Also change compiler library and libunwind from libgcc GCC implementation to LLVM's compiler-rt
+    # See https://clang.llvm.org/docs/Toolchain.html for details
+    # LINKFLAGS variable contains required link flags
     if (${CLANG_LIBCPP} MATCHES "CLANG_LIBCPP-NOTFOUND")
         set(LIBCXX "libstdc++11")
+        set(LINKFLAGS "")
     else()
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         set(LIBCXX "libc++")
+        set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
     endif()
 
     if (${CLANG_LIBCPP_ABI} MATCHES "CLANG_LIBCPP_ABI-NOTFOUND")
@@ -137,6 +143,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
 
 else() #---------------------------------------------------------------------------- GNU
     set(LIBCXX "libstdc++11")
+    set(LINKFLAGS "")
 endif() #--------------------------------------------------------------------------- Clang
 
 add_library(
@@ -190,7 +197,7 @@ conan_cmake_run(REQUIRES
     benchmark/1.8.0
     BASIC_SETUP CMAKE_TARGETS
     SETTINGS ${CONAN_SETTINGS}
-    ENV CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+    ENV CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LDFLAGS=${LINKFLAGS}
     BUILD missing
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
                 set(LINKFLAGS "${LINKFLAGS} -unwindlib=libunwind")
             else()
                 message(STATUS "libunwind not found, using libgcc")
-                set(LINKFLAGS "${LINKFLAGS} -unwindlib=libgcc")
+                set(LINKFLAGS "${LINKFLAGS} -unwindlib=libgcc -lgcc_s")
             endif()
         endif()
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKFLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,43 +41,9 @@ add_compile_options(
   "$<$<AND:$<CXX_COMPILER_ID:GNU,Clang,AppleClang>,$<CONFIG:RELEASE>>:-fno-rtti;-Wall>"
 )
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #------------------------------------- Clang
-    ############## LLVM CONFIGURATION #################
-    # https://github.com/nsumner/llvm-demo Example LLVM Build
-
-    # LLVM_DIR must be set to the prefix of /share/llvm/cmake via commandline
-    find_package(LLVM REQUIRED CONFIG)
-    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-    # We incorporate the CMake features provided by LLVM:
-    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-    include(AddLLVM)
-
-    message("LLVM STATUS:
-        Definitions ${LLVM_DEFINITIONS}
-        Includes    ${LLVM_INCLUDE_DIRS}
-        Libraries   ${LLVM_LIBRARY_DIRS}
-        Targets     ${LLVM_TARGETS_TO_BUILD}
-        CXX         ${CMAKE_CXX_COMPILER}
-        C           ${CMAKE_C_COMPILER}"
-    )
-
-    # Now set the LLVM header and library paths:
-    include_directories(
-        ${LLVM_INCLUDE_DIRS}
-        ${LLVM_INCLUDE_DIRS}/c++/v1
-        ${CMAKE_CURRENT_SOURCE_DIR}/
-        ${CMAKE_CURRENT_SOURCE_DIR}/header)
-
-    link_directories(${LLVM_LIBRARY_DIRS})
-    add_definitions(${LLVM_DEFINITIONS})
-
-else() #---------------------------------------------------------------------------- GNU
-    include_directories(
-        ${CMAKE_CURRENT_SOURCE_DIR}/
-        ${CMAKE_CURRENT_SOURCE_DIR}/header)
-endif() #--------------------------------------------------------------------------- Clang
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+    ${CMAKE_CURRENT_SOURCE_DIR}/header)
 
 ############## FINAL PROJECT CONFIG #################
 
@@ -111,6 +77,13 @@ file(GLOB ${PROJECT_NAME}_HEADERS
 )
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #------------------------------------- Clang
+    ############## LLVM CONFIGURATION #################
+    # https://github.com/nsumner/llvm-demo Example LLVM Build
+
+    # LLVM_DIR must be set to the prefix of /share/llvm/cmake via commandline
+    find_package(LLVM REQUIRED CONFIG)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} at ${LLVM_LIBRARY_DIRS}")
+
     find_library(CLANG_LIBCPP
         NAMES libc++ c++
         HINTS ${LLVM_LIBRARY_DIRS})
@@ -119,8 +92,10 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
         NAMES libc++abi c++abi
         HINTS ${LLVM_LIBRARY_DIRS})
 
-    message(STATUS "Find CLANG_LIBCPP=${CLANG_LIBCPP}")
-    message(STATUS "Find CLANG_LIBCPP_ABI=${CLANG_LIBCPP_ABI}")
+    message(STATUS "Found CLANG_LIBCPP=${CLANG_LIBCPP}")
+    message(STATUS "Found CLANG_LIBCPP_ABI=${CLANG_LIBCPP_ABI}")
+
+    # Linker flags for targets and Conan
     set(LINKFLAGS "")
     ### https://stackoverflow.com/questions/43662736/cmake-switch-between-clang-g-and-libc-libstdc
 
@@ -170,22 +145,8 @@ add_library(
     ${${PROJECT_NAME}_HEADERS}
 )
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #------------------------------------- Clang
-    ### https://stackoverflow.com/questions/62926242/how-to-link-all-llvm-libraries-in-cmake
-    execute_process(COMMAND llvm-config --libs all
-                    OUTPUT_VARIABLE REQ_LLVM_LIBRARIES)
-
-    #llvm_map_components_to_libnames(REQ_LLVM_LIBRARIES
-    #  ${LLVM_TARGETS_TO_BUILD}
-    #  core asmparser linker bitreader bitwriter irreader
-    #  target mc support native
-    #  all #all-targets amdgpu amdgpuasmparser amdgpucodegen amdgpudesc amdgpudisassembler amdgpuinfo amdgpuutils analysis arm armasmparser armcodegen armdesc armdisassembler arminfo armutils asmparser asmprinter avr avrasmparser avrcodegen avrdesc avrdisassembler avrinfo binaryformat bitreader bitstreamreader bitwriter bpf bpfasmparser bpfcodegen bpfdesc bpfdisassembler bpfinfo cfguard codegen core coroutines coverage debuginfocodeview debuginfodwarf debuginfogsym debuginfomsf debuginfopdb demangle dlltooldriver dwarflinker engine executionengine frontendopenmp fuzzmutate globalisel hexagon hexagonasmparser hexagoncodegen hexagondesc hexagondisassembler hexagoninfo instcombine instrumentation interpreter ipo irreader jitlink lanai lanaiasmparser lanaicodegen lanaidesc lanaidisassembler lanaiinfo libdriver lineeditor linker lto mc mca mcdisassembler mcjit mcparser mips mipsasmparser mipscodegen mipsdesc mipsdisassembler mipsinfo mirparser msp430 msp430asmparser msp430codegen msp430desc msp430disassembler msp430info native nativecodegen nvptx nvptxcodegen nvptxdesc nvptxinfo objcarcopts object objectyaml option orcerror orcjit passes perfjitevents powerpc powerpcasmparser powerpccodegen powerpcdesc powerpcdisassembler powerpcinfo profiledata remarks riscv riscvasmparser riscvcodegen riscvdesc riscvdisassembler riscvinfo riscvutils runtimedyld scalaropts selectiondag sparc sparcasmparser sparccodegen sparcdesc sparcdisassembler sparcinfo support symbolize systemz systemzasmparser systemzcodegen systemzdesc systemzdisassembler systemzinfo tablegen target textapi transformutils vectorize webassembly webassemblyasmparser webassemblycodegen webassemblydesc webassemblydisassembler webassemblyinfo windowsmanifest x86 x86asmparser x86codegen x86desc x86disassembler x86info x86utils xcore xcorecodegen xcoredesc xcoredisassembler xcoreinfo xray
-    #)
-
-    target_link_libraries(${PROJECT_NAME}
-        INTERFACE ${REQ_LLVM_LIBRARIES}
-    )
-endif() #--------------------------------------------------------------------------- Clang
+# Unneeded transitional variable
+set(REQ_LLVM_LIBRARIES "")
 
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,19 +121,23 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
 
     message(STATUS "Find CLANG_LIBCPP=${CLANG_LIBCPP}")
     message(STATUS "Find CLANG_LIBCPP_ABI=${CLANG_LIBCPP_ABI}")
+    set(LINKFLAGS "")
     ### https://stackoverflow.com/questions/43662736/cmake-switch-between-clang-g-and-libc-libstdc
 
-    # Also change compiler library and libunwind from libgcc GCC implementation to LLVM's compiler-rt
-    # See https://clang.llvm.org/docs/Toolchain.html for details
-    # LINKFLAGS variable contains required link flags
     if (${CLANG_LIBCPP} MATCHES "CLANG_LIBCPP-NOTFOUND")
         set(LIBCXX "libstdc++11")
-        set(LINKFLAGS "")
     else()
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
+        # Change compiler library and libunwind from libgcc GCC implementation to LLVM's compiler-rt
+        # See https://clang.llvm.org/docs/Toolchain.html for details
+        # LINKFLAGS variable contains required link flags
+        set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
+        if (NOT APPLE)
+            set(LINKFLAGS "${LINKFLAGS} -unwindlib=libunwind")
+        endif()
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKFLAGS}")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKFLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         set(LIBCXX "libc++")
-        set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
     endif()
 
     if (${CLANG_LIBCPP_ABI} MATCHES "CLANG_LIBCPP_ABI-NOTFOUND")
@@ -143,8 +147,10 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
 
 else() #---------------------------------------------------------------------------- GNU
     set(LIBCXX "libstdc++11")
-    set(LINKFLAGS "")
 endif() #--------------------------------------------------------------------------- Clang
+
+message(STATUS "Using shared linker flags : ${CMAKE_SHARED_LINKER_FLAGS}")
+message(STATUS "Using exe linker flags    : ${CMAKE_EXE_LINKER_FLAGS}")
 
 add_library(
     ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,14 +132,19 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
         # LINKFLAGS variable contains required link flags
         set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt")
 
-        find_library(
-            LIBUNWIND_LIBRARY
-            NAMES libunwind.a
-            PATH_SUFFIXES lib lib64)
+        if (NOT APPLE)
+            find_library(
+                LIBUNWIND_LIBRARY
+                NAMES libunwind.a
+                PATH_SUFFIXES lib lib64)
 
-        message(STATUS "Unwind found: ${LIBUNWIND_LIBRARY}")
-        if (NOT APPLE AND LIBUNWIND_LIBRARY)
-            set(LINKFLAGS "${LINKFLAGS} -unwindlib=libunwind")
+            if (LIBUNWIND_LIBRARY)
+                message(STATUS "libunwind found: ${LIBUNWIND_LIBRARY}, using libunwind")
+                set(LINKFLAGS "${LINKFLAGS} -unwindlib=libunwind")
+            else()
+                message(STATUS "libunwind not found, using libgcc")
+                set(LINKFLAGS "${LINKFLAGS} -unwindlib=libgcc")
+            endif()
         endif()
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKFLAGS}")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKFLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,15 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") #---------------------------------
         # Change compiler library and libunwind from libgcc GCC implementation to LLVM's compiler-rt
         # See https://clang.llvm.org/docs/Toolchain.html for details
         # LINKFLAGS variable contains required link flags
-        set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt -unwindlib=libunwind")
-        if (NOT APPLE)
+        set(LINKFLAGS "-stdlib=libc++ -rtlib=compiler-rt")
+
+        find_library(
+            LIBUNWIND_LIBRARY
+            NAMES libunwind.a
+            PATH_SUFFIXES lib lib64)
+
+        message(STATUS "Unwind found: ${LIBUNWIND_LIBRARY}")
+        if (NOT APPLE AND LIBUNWIND_LIBRARY)
             set(LINKFLAGS "${LINKFLAGS} -unwindlib=libunwind")
         endif()
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKFLAGS}")


### PR DESCRIPTION
PR fixes the problem with linking to `libgcc_s`, which contains GCC-specific implementation of unwind and compiler runtime. See https://clang.llvm.org/docs/Toolchain.html for the description of unwind and internals implementation. The fix is applied only for non-macOS clang builds.

Check: `ldd build/bin/dataflow | grep -E 'unwind|libgcc'` should not contain `libgcc_s`.